### PR TITLE
query dom after window has loaded

### DIFF
--- a/src/components/ebay-predict/prefetch.js
+++ b/src/components/ebay-predict/prefetch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var predictElem = document.querySelector('noscript.ebay-predict');
+var predictElem;
 
 var requestIdleCallback = window.requestIdleCallback ||
     function(cb) {
@@ -58,6 +58,7 @@ function callPredictService() {
 
 function init() {
     window.addEventListener('load', function() {
+        predictElem = document.querySelector('noscript.ebay-predict');
         var delay = parseInt(predictElem.dataset.delay, 10) || 200;
         var timeoutID = setTimeout(function() {
             clearTimeout(timeoutID);


### PR DESCRIPTION
when using lasso and ebay-predict like this:
```marko
<lasso-body />
<ebay-predict src=input.src />
```

then the predict.js is run before the dom has parsed the html rendered by `ebay-predict`, so the noscript tag is never found.

This PR defers querying the dom until after the window has loaded, so placement of the tag in the template is not significant.