### PR TITLE
check for predictElem first

### DIFF
--- a/src/components/ebay-predict/prefetch.js
+++ b/src/components/ebay-predict/prefetch.js
@@ -59,6 +59,11 @@ function callPredictService() {
 function init() {
     window.addEventListener('load', function() {
         predictElem = document.querySelector('noscript.ebay-predict');
+
+        if (!predictElem) {
+            return;
+        }
+
         // If requestIdleCallback is present, then ignore the attribute and use min value 1
         var delay = window.requestIdleCallback ? 1 : (parseInt(predictElem.dataset.delay, 10) || 200);
         var timeoutID = setTimeout(function() {


### PR DESCRIPTION
otherwise, console throws an error that it `cannot find dataset of null`.